### PR TITLE
Fix PHP8.1 throw 'Deprecated'

### DIFF
--- a/src/wp-includes/pomo/plural-forms.php
+++ b/src/wp-includes/pomo/plural-forms.php
@@ -239,13 +239,14 @@ if ( ! class_exists( 'Plural_Forms', false ) ) :
 		 * @param int $num Number to get plural form for.
 		 * @return int Plural form value.
 		 */
-                public function get( $num ) {
-                        if ( isset( $this->cache[ (int) $num ] ) ) {
-                                return $this->cache[ $num ];
-                        }
-                        $this->cache[ (int) $num ] = $this->execute( (int) $num );
-                        return $this->cache[ (int) $num ];
-                }
+		public function get( $num ) {
+			$num = (int) $num;
+			if ( isset( $this->cache[ $num ] ) ) {
+				return $this->cache[ $num ];
+			}
+			$this->cache[ $num ] = $this->execute( $num );
+			return $this->cache[ $num ];
+		}
 
 		/**
 		 * Execute the plural form function.

--- a/src/wp-includes/pomo/plural-forms.php
+++ b/src/wp-includes/pomo/plural-forms.php
@@ -239,13 +239,13 @@ if ( ! class_exists( 'Plural_Forms', false ) ) :
 		 * @param int $num Number to get plural form for.
 		 * @return int Plural form value.
 		 */
-		public function get( $num ) {
-			if ( isset( $this->cache[ $num ] ) ) {
-				return $this->cache[ $num ];
-			}
-			$this->cache[ $num ] = $this->execute( $num );
-			return $this->cache[ $num ];
-		}
+                public function get( $num ) {
+                        if ( isset( $this->cache[ (int) $num ] ) ) {
+                                return $this->cache[ $num ];
+                        }
+                        $this->cache[ (int) $num ] = $this->execute( (int) $num );
+                        return $this->cache[ (int) $num ];
+                }
 
 		/**
 		 * Execute the plural form function.


### PR DESCRIPTION
In PHP8.1,Implicit incompatible float to int conversion is deprecated.
Because of it, wordpress will throw a PHP Deprecated in page footer.

Trac ticket: https://core.trac.wordpress.org/ticket/54996
